### PR TITLE
fs: Fix `copy_recursive`

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2192,7 +2192,15 @@ mod tests {
         )
         .await;
 
-        println!("{:#?}", fs.files());
+        assert_eq!(
+            fs.files(),
+            vec![
+                PathBuf::from(path!("/outer/inner1/a")),
+                PathBuf::from(path!("/outer/inner1/b")),
+                PathBuf::from(path!("/outer/inner2/c")),
+                PathBuf::from(path!("/outer/inner1/inner3/d")),
+            ]
+        );
 
         let source = Path::new(path!("/outer"));
         let target = Path::new(path!("/outer/inner1/outer"));
@@ -2200,6 +2208,18 @@ mod tests {
             .await
             .unwrap();
 
-        println!("{:#?}", fs.files());
+        assert_eq!(
+            fs.files(),
+            vec![
+                PathBuf::from(path!("/outer/inner1/a")),
+                PathBuf::from(path!("/outer/inner1/b")),
+                PathBuf::from(path!("/outer/inner2/c")),
+                PathBuf::from(path!("/outer/inner1/inner3/d")),
+                PathBuf::from(path!("/outer/inner1/outer/inner1/a")),
+                PathBuf::from(path!("/outer/inner1/outer/inner1/b")),
+                PathBuf::from(path!("/outer/inner1/outer/inner2/c")),
+                PathBuf::from(path!("/outer/inner1/outer/inner1/inner3/d")),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Closes #24746

This PR modifies the implementation of `copy_recursive`. Previously, we were copying and pasting simultaneously, which caused an issue when a user copied a folder into one of its subfolders. This resulted in new content being created in the folder while copying, and subsequent recursive calls to `copy_recursive` would continue this process, leading to an infinite loop.

In this PR, the approach has been changed: we now first collect the paths of the files to be copied, and only then perform the copy operation.

Additionally, we have added corresponding tests. On the main branch, this test would previously run indefinitely.

Release Notes:

- Fixed `copy_recursive` runs infinitely when copying a folder into its subfolder.
